### PR TITLE
Fix NLLB tokenizer API usage

### DIFF
--- a/module.py
+++ b/module.py
@@ -47,7 +47,7 @@ class UnlimitedTranslator:
         with torch.no_grad():
             generated_tokens = self.model.generate(
                 **inputs,
-                forced_bos_token_id=self.tokenizer.lang_code_to_id[self.dest],
+                forced_bos_token_id=self.tokenizer.convert_tokens_to_ids(self.dest),
                 src_lang=self.src,
                 max_length=1024,
             )


### PR DESCRIPTION
## Summary
- update call to `generate()` to use `convert_tokens_to_ids`

## Testing
- `python -m py_compile module.py`

------
https://chatgpt.com/codex/tasks/task_e_6841cd21afc4832b8bd07d41cdc8c180