### PR TITLE
Use open-source GPT model for translation

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,21 +1,10 @@
 import argparse
-import module
+from module import PromptTranslator
 
-parser = argparse.ArgumentParser(description="Translate text using NLLB or a prompt-based model")
+parser = argparse.ArgumentParser(description="Translate text using a GPT model")
 parser.add_argument("text", help="Text to translate")
-parser.add_argument("--src", dest="src", default=None, help="Source language code")
 parser.add_argument("--dest", dest="dest", default="en", help="Destination language code")
-parser.add_argument(
-    "--engine",
-    choices=["nllb", "prompt"],
-    default="nllb",
-    help="Translation engine to use",
-)
 args = parser.parse_args()
 
-if args.engine == "prompt":
-    translator = module.PromptTranslator(text=args.text, dest=args.dest)
-else:
-    translator = module.UnlimitedTranslator(text=args.text, src=args.src, dest=args.dest)
-
+translator = PromptTranslator(text=args.text, dest=args.dest)
 print(translator.translated_text)

--- a/module.py
+++ b/module.py
@@ -1,87 +1,18 @@
 from typing import Optional, Dict
 
-from langdetect import detect
-from nltk import tokenize
 from transformers import (
     AutoTokenizer,
-    AutoModelForSeq2SeqLM,
     AutoModelForCausalLM,
     pipeline,
 )
 import torch
 
-# Mapping from ISO 639-1 codes to NLLB-200 language codes
-LANG_CODE_MAP: Dict[str, str] = {
-    "af": "afr_Latn",
-    "sq": "sqi_Latn",
-    "am": "amh_Ethi",
-    "ar": "arb_Arab",
-    "hy": "hye_Armn",
-    "az": "azj_Latn",
-    "be": "bel_Cyrl",
-    "bn": "ben_Beng",
-    "bs": "bos_Latn",
-    "bg": "bul_Cyrl",
-    "ca": "cat_Latn",
-    "zh": "zho_Hans",
-    "zh-cn": "zho_Hans",
-    "zh-tw": "zho_Hant",
-    "hr": "hrv_Latn",
-    "cs": "ces_Latn",
-    "da": "dan_Latn",
-    "nl": "nld_Latn",
-    "en": "eng_Latn",
-    "et": "est_Latn",
-    "fi": "fin_Latn",
-    "fr": "fra_Latn",
-    "ka": "kat_Geor",
-    "de": "deu_Latn",
-    "el": "ell_Grek",
-    "gu": "guj_Gujr",
-    "ht": "hat_Latn",
-    "ha": "hau_Latn",
-    "he": "heb_Hebr",
-    "hi": "hin_Deva",
-    "hu": "hun_Latn",
-    "is": "isl_Latn",
-    "id": "ind_Latn",
-    "it": "ita_Latn",
-    "ja": "jpn_Jpan",
-    "kn": "kan_Knda",
-    "kk": "kaz_Cyrl",
-    "ko": "kor_Hang",
-    "lv": "lvs_Latn",
-    "lt": "lit_Latn",
-    "mk": "mkd_Cyrl",
-    "ms": "zsm_Latn",
-    "mr": "mar_Deva",
-    "ne": "npi_Deva",
-    "no": "nob_Latn",
-    "fa": "pes_Arab",
-    "pl": "pol_Latn",
-    "pt": "por_Latn",
-    "pa": "pan_Guru",
-    "ro": "ron_Latn",
-    "ru": "rus_Cyrl",
-    "sr": "srp_Cyrl",
-    "sk": "slk_Latn",
-    "sl": "slv_Latn",
-    "es": "spa_Latn",
-    "sw": "swh_Latn",
-    "sv": "swe_Latn",
-    "ta": "tam_Taml",
-    "te": "tel_Telu",
-    "th": "tha_Thai",
-    "tr": "tur_Latn",
-    "uk": "ukr_Cyrl",
-    "ur": "urd_Arab",
-    "vi": "vie_Latn",
-}
 
-MODEL_NAME = "facebook/nllb-200-distilled-600M"
 
-# Default chat-oriented model used for prompt-based translation
-CHAT_MODEL = "HuggingFaceH4/zephyr-7b-beta"
+# Default chat-oriented model used for prompt-based translation. The
+# lightweight `openai-community/openai-gpt` model is used by default
+# to avoid the heavy NLLB dependency when translating via prompts.
+CHAT_MODEL = "openai-community/openai-gpt"
 
 # Prompt template for the chat model
 PROMPT_TEMPLATE = """
@@ -107,58 +38,6 @@ PROMPT_TEMPLATE = """
 {text}
 """
 
-
-class UnlimitedTranslator:
-    """Translate large texts using the NLLB neural model."""
-
-    def __init__(
-        self,
-        text: str,
-        src: Optional[str] = None,
-        dest: str = "en",
-        device: Optional[str] = None,
-    ) -> None:
-        self.text = text
-        self.src = self._resolve_lang(src or detect(text))
-        self.dest = self._resolve_lang(dest)
-        if device is None:
-            if torch.backends.mps.is_available():
-                device = "mps"
-            elif torch.cuda.is_available():
-                device = "cuda"
-            else:
-                device = "cpu"
-        self.device = torch.device(device)
-        self.tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
-        self.tokenizer.src_lang = self.src
-        self.model = AutoModelForSeq2SeqLM.from_pretrained(MODEL_NAME).to(self.device)
-        self.translated_text = self._translate_text()
-
-    def _resolve_lang(self, lang: str) -> str:
-        lang = lang.lower()
-        return LANG_CODE_MAP.get(lang, lang)
-
-    def _get_lang_id(self, lang: str) -> int:
-        """Return the token ID used for the given language code."""
-        if hasattr(self.tokenizer, "lang_code_to_id"):
-            return self.tokenizer.lang_code_to_id[lang]
-        return self.tokenizer.convert_tokens_to_ids(lang)
-
-    def _translate_sentence(self, sentence: str) -> str:
-        inputs = self.tokenizer(sentence, return_tensors="pt").to(self.device)
-        with torch.no_grad():
-            bos_token_id = self._get_lang_id(self.dest)
-            generated_tokens = self.model.generate(
-                **inputs,
-                forced_bos_token_id=bos_token_id,
-                max_length=1024,
-            )
-        return self.tokenizer.decode(generated_tokens[0], skip_special_tokens=True)
-
-    def _translate_text(self) -> str:
-        sentences = tokenize.sent_tokenize(self.text)
-        outputs = [self._translate_sentence(sent) for sent in sentences]
-        return " ".join(outputs)
 
 
 class PromptTranslator:

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # About
-<p>This python script translates text of any length using the open-source <a href="https://github.com/facebookresearch/nllb">NLLB</a> neural model instead of Google services.<br>
+<p>This python script translates text of any length using an open-source <a href="https://huggingface.co/docs/transformers/en/model_doc/openai-gpt">GPT model</a> with a custom prompt.<br>
 
 + <b>No limits.</b>
 + <b>Fully free.</b>
@@ -37,7 +37,7 @@ python <<< 'import nltk' && python <<< 'nltk.download("punkt")'
 ```python
 import module
 
-tr = module.UnlimitedTranslator(text='Hello, World!', src='en', dest='fr')
+tr = module.PromptTranslator(text='Hello, World!', dest='fr')
 translated_text = tr.translated_text
 
 if __name__ == '__main__':
@@ -47,15 +47,11 @@ if __name__ == '__main__':
 The result will be:
 ``` Result: Bonjour le monde! ```
 
-You can also run the provided `example.py` script from the command line. Use the
-`--engine` option to choose between the lightweight NLLB translator and the more
-resource intensive prompt-based model:
+You can run the provided `example.py` script from the command line:
 
 ```bash
-python example.py "Hello, world!" --dest fr --engine prompt
+python example.py "Hello, world!" --dest fr
 ```
-
-# Prompt-based translator
 
 # Prompt-based translator
 
@@ -67,5 +63,5 @@ from module import PromptTranslator
 tr = PromptTranslator(text="Hello, World!", dest="fr")
 print(tr.translated_text)
 ```
-Loading the default chat model (`HuggingFaceH4/zephyr-7b-beta`) may require
-several gigabytes of RAM and is best run on a machine with a GPU.
+Loading the default chat model (`openai-community/openai-gpt`) is lightweight
+and can run on modest hardware.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 tk==0.1.0
 regex==2022.7.25
-nltk==3.7
-langdetect==1.0.9
 transformers==4.52.4
 sentencepiece==0.2.0
 torch


### PR DESCRIPTION
## Summary
- remove NLLB translator code
- use `openai-community/openai-gpt` for prompt-based translation
- simplify example script and documentation
- drop unused dependencies

## Testing
- `python -m py_compile example.py module.py`

------
https://chatgpt.com/codex/tasks/task_e_6842a7be1f58832b9a6b4ed4e8f92d28